### PR TITLE
Remove send button of Authorization Form

### DIFF
--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -7,7 +7,3 @@
 </div>
 
 <%= form.hidden_field :handler_name %>
-
-<div class="actions">
-  <%= form.submit t("authorize", scope: "decidim.verifications.authorizations.new"), class: "button expanded" %>
-</div>


### PR DESCRIPTION
As PR 3211 of Decidim was merged, it's necessary to remove the send button of the Authorization Form