### PR TITLE
[FIX] Removed forcing time-zone in DateTime inputs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,6 @@ module DevelopmentApp
     
     config.time_zone = 'Madrid'
     config.active_record.default_timezone = :local
-    config.active_record.time_zone_aware_attributes = false
     
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Removes forcing time-zone in DateTime inputs

Related to basecamp's: https://3.basecamp.com/4186608/buckets/11241826/todos/2354029440
Fixes: https://github.com/decidim/decidim/issues/5689

![imagen](https://user-images.githubusercontent.com/56717126/73918991-f33df280-48c2-11ea-9814-4785e65be5c2.png)
